### PR TITLE
Switch from assertify to assert2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,24 +30,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
-name = "assertify"
-version = "0.6.1"
+name = "assert2"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef37f1483f4889ed06836d9d04e965c7b7c19aa2acb27e4a5fdc051c5cdbfdbd"
+checksum = "01456b66bf7c5c8e9e86af730e50f313ba9458fcdd622b11571e3f8fd727ca5d"
 dependencies = [
- "assertify_proc_macros",
- "proc-macro-hack",
+ "assert2-macros",
+ "atty",
+ "yansi",
 ]
 
 [[package]]
-name = "assertify_proc_macros"
-version = "0.6.1"
+name = "assert2-macros"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dba324a474f003d37e52373f230276b28ec9c1612d624a8bc91b9fcdf3e4940"
+checksum = "45c77509bbd2708f7b3f02350c5481bf167f235aeba95e86fd12a2c6dfe6f61c"
 dependencies = [
- "proc-macro-hack",
  "proc-macro2",
  "quote",
+ "rustc_version",
  "syn",
 ]
 
@@ -414,12 +415,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-hack"
-version = "0.5.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -448,7 +443,7 @@ name = "rederr"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "assertify",
+ "assert2",
  "atty",
  "clap",
  "duration-str",
@@ -468,6 +463,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -478,6 +482,12 @@ name = "scratch"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
+
+[[package]]
+name = "semver"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
 
 [[package]]
 name = "serde"
@@ -680,3 +690,9 @@ name = "wyz"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,4 +23,4 @@ popol = "2.0.0"
 termcolor = "1.1.3"
 
 [dev-dependencies]
-assertify = "0.6.0"
+assert2 = "0.3.7"

--- a/src/main.rs
+++ b/src/main.rs
@@ -257,28 +257,28 @@ fn wait_status_to_code(status: process::ExitStatus) -> Option<i32> {
 #[cfg(test)]
 mod tests {
     use crate::*;
-    use assertify::assertify;
+    use assert2::{assert, check};
     use clap::error::{ContextKind, ContextValue, ErrorKind};
 
     #[test]
     fn args_invalid_long_option() {
         let parse =
             Params::try_parse_from(["redder", "--foo", "-s", "command"]);
-        assertify!(parse.is_err());
+        assert!(parse.is_err());
         let error = parse.unwrap_err();
-        assertify!(error.kind() == ErrorKind::UnknownArgument);
+        check!(error.kind() == ErrorKind::UnknownArgument);
         let value = ContextValue::String("--foo".to_owned());
-        assertify!(error.get(ContextKind::InvalidArg) == Some(&value));
+        check!(error.get(ContextKind::InvalidArg) == Some(&value));
     }
 
     #[test]
     fn args_invalid_short_option() {
         let parse = Params::try_parse_from(["redder", "-X", "-s", "command"]);
-        assertify!(parse.is_err());
+        assert!(parse.is_err());
         let error = parse.unwrap_err();
-        assertify!(error.kind() == ErrorKind::UnknownArgument);
+        check!(error.kind() == ErrorKind::UnknownArgument);
         let value = ContextValue::String("-X".to_owned());
-        assertify!(error.get(ContextKind::InvalidArg) == Some(&value));
+        check!(error.get(ContextKind::InvalidArg) == Some(&value));
     }
 
     #[test]
@@ -290,10 +290,10 @@ mod tests {
             "--foo",
         ])
         .unwrap();
-        assertify!(params.command == "command");
-        assertify!(params.args == ["--foo"]);
-        assertify!(params.always_color == true);
-        assertify!(params.separate == false);
+        check!(params.command == "command");
+        check!(params.args == ["--foo"]);
+        check!(params.always_color == true);
+        check!(params.separate == false);
     }
 
     #[test]
@@ -305,10 +305,10 @@ mod tests {
             "-f",
         ])
         .unwrap();
-        assertify!(params.command == "command");
-        assertify!(params.args == ["-f"]);
-        assertify!(params.always_color == true);
-        assertify!(params.separate == false);
+        check!(params.command == "command");
+        check!(params.args == ["-f"]);
+        check!(params.always_color == true);
+        check!(params.separate == false);
     }
 
     #[test]
@@ -321,10 +321,10 @@ mod tests {
             "--foo",
         ])
         .unwrap();
-        assertify!(params.command == "command");
-        assertify!(params.args == ["-f", "--foo"]);
-        assertify!(params.always_color == true);
-        assertify!(params.separate == false);
+        check!(params.command == "command");
+        check!(params.args == ["-f", "--foo"]);
+        check!(params.always_color == true);
+        check!(params.separate == false);
     }
 
     #[test]
@@ -337,10 +337,10 @@ mod tests {
             "--separate",
         ])
         .unwrap();
-        assertify!(params.command == "command");
-        assertify!(params.args == ["--separate"]);
-        assertify!(params.always_color == true);
-        assertify!(params.separate == false);
+        check!(params.command == "command");
+        check!(params.args == ["--separate"]);
+        check!(params.always_color == true);
+        check!(params.separate == false);
     }
 
     #[test]
@@ -353,10 +353,10 @@ mod tests {
             "--separate",
         ])
         .unwrap();
-        assertify!(params.command == "command");
-        assertify!(params.args == ["-s"]);
-        assertify!(params.always_color == false);
-        assertify!(params.separate == true);
+        check!(params.command == "command");
+        check!(params.args == ["-s"]);
+        check!(params.always_color == false);
+        check!(params.separate == true);
     }
 
     #[test]
@@ -364,10 +364,10 @@ mod tests {
     fn args_our_short_option_after_command() {
         let params =
             Params::try_parse_from(["redder", "-c", "command", "-s"]).unwrap();
-        assertify!(params.command == "command");
-        assertify!(params.args == ["-s"]);
-        assertify!(params.always_color == true);
-        assertify!(params.separate == false);
+        check!(params.command == "command");
+        check!(params.args == ["-s"]);
+        check!(params.always_color == true);
+        check!(params.separate == false);
     }
 
     #[test]
@@ -375,10 +375,10 @@ mod tests {
     fn args_our_same_short_option_after_command() {
         let params =
             Params::try_parse_from(["redder", "-s", "command", "-s"]).unwrap();
-        assertify!(params.command == "command");
-        assertify!(params.args == ["-s"]);
-        assertify!(params.always_color == false);
-        assertify!(params.separate == true);
+        check!(params.command == "command");
+        check!(params.args == ["-s"]);
+        check!(params.always_color == false);
+        check!(params.separate == true);
     }
 
     #[test]
@@ -387,10 +387,10 @@ mod tests {
             "redder", "-s", "command", "-abc", "foo", "--", "-s", "--bar",
         ])
         .unwrap();
-        assertify!(params.command == "command");
-        assertify!(params.args == ["-abc", "foo", "--", "-s", "--bar"]);
-        assertify!(params.always_color == false);
-        assertify!(params.separate == true);
+        check!(params.command == "command");
+        check!(params.args == ["-abc", "foo", "--", "-s", "--bar"]);
+        check!(params.always_color == false);
+        check!(params.separate == true);
     }
 
     #[test]
@@ -402,7 +402,7 @@ mod tests {
             "command",
         ]);
         let error = parse.expect_err("expected parse to fail");
-        assertify!(error.kind() == ErrorKind::ValueValidation);
+        check!(error.kind() == ErrorKind::ValueValidation);
     }
 
     #[test]
@@ -414,7 +414,7 @@ mod tests {
             "command",
         ])
         .unwrap();
-        assertify!(params.idle_timeout == Some(Duration::from_secs(2)));
+        check!(params.idle_timeout == Some(Duration::from_secs(2)));
     }
 
     #[test]
@@ -426,7 +426,7 @@ mod tests {
             "command",
         ])
         .unwrap();
-        assertify!(params.idle_timeout == Some(Duration::from_secs(2)));
+        check!(params.idle_timeout == Some(Duration::from_secs(2)));
     }
 
     #[test]
@@ -438,7 +438,7 @@ mod tests {
             "command",
         ])
         .unwrap();
-        assertify!(params.idle_timeout == Some(Duration::from_millis(2001)));
+        check!(params.idle_timeout == Some(Duration::from_millis(2001)));
     }
 
     #[test]
@@ -450,9 +450,7 @@ mod tests {
             "command",
         ])
         .unwrap();
-        assertify!(
-            params.idle_timeout == Some(Duration::from_secs(2 * 60 * 60))
-        );
+        check!(params.idle_timeout == Some(Duration::from_secs(2 * 60 * 60)));
     }
 
     #[test]
@@ -464,8 +462,8 @@ mod tests {
             "command",
         ]);
         let error = parse.expect_err("expected parse to fail");
-        assertify!(error.kind() == ErrorKind::ValueValidation);
-        assertify!(error.to_string().contains("negative"));
+        check!(error.kind() == ErrorKind::ValueValidation);
+        check!(error.to_string().contains("negative"));
     }
 
     #[test]
@@ -477,7 +475,7 @@ mod tests {
             "command",
         ])
         .unwrap();
-        assertify!(params.idle_timeout == Some(Duration::ZERO));
+        check!(params.idle_timeout == Some(Duration::ZERO));
     }
 
     #[test]
@@ -489,7 +487,7 @@ mod tests {
             "command",
         ])
         .unwrap();
-        assertify!(
+        check!(
             params.idle_timeout == Some(Duration::from_millis(i32::MAX as u64))
         );
     }
@@ -503,8 +501,8 @@ mod tests {
             "command",
         ]);
         let error = parse.expect_err("expected parse to fail");
-        assertify!(error.kind() == ErrorKind::ValueValidation);
-        assertify!(error.to_string().contains("cannot be larger"));
+        check!(error.kind() == ErrorKind::ValueValidation);
+        check!(error.to_string().contains("cannot be larger"));
     }
 
     #[test]
@@ -516,8 +514,8 @@ mod tests {
             "command",
         ]);
         let error = parse.expect_err("expected parse to fail");
-        assertify!(error.kind() == ErrorKind::ValueValidation);
-        assertify!(error.to_string().contains("cannot be larger"));
+        check!(error.kind() == ErrorKind::ValueValidation);
+        check!(error.to_string().contains("cannot be larger"));
     }
 
     #[test]
@@ -529,7 +527,7 @@ mod tests {
             "command",
         ]);
         let error = parse.expect_err("expected parse to fail");
-        assertify!(error.kind() == ErrorKind::ValueValidation);
-        assertify!(error.to_string().contains("milliseconds"));
+        check!(error.kind() == ErrorKind::ValueValidation);
+        check!(error.to_string().contains("milliseconds"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -257,39 +257,41 @@ fn wait_status_to_code(status: process::ExitStatus) -> Option<i32> {
 #[cfg(test)]
 mod tests {
     use crate::*;
-    use assert2::{assert, check};
-    use clap::error::{ContextKind, ContextValue, ErrorKind};
+    use assert2::{check, let_assert};
+    use clap::error::{
+        ContextKind::InvalidArg, ContextValue::String, ErrorKind,
+    };
 
     #[test]
     fn args_invalid_long_option() {
-        let parse =
-            Params::try_parse_from(["redder", "--foo", "-s", "command"]);
-        assert!(parse.is_err());
-        let error = parse.unwrap_err();
+        let_assert!(
+            Err(error) =
+                Params::try_parse_from(["redder", "--foo", "-s", "command"])
+        );
         check!(error.kind() == ErrorKind::UnknownArgument);
-        let value = ContextValue::String("--foo".to_owned());
-        check!(error.get(ContextKind::InvalidArg) == Some(&value));
+        check!(error.get(InvalidArg) == Some(&String("--foo".into())));
     }
 
     #[test]
     fn args_invalid_short_option() {
-        let parse = Params::try_parse_from(["redder", "-X", "-s", "command"]);
-        assert!(parse.is_err());
-        let error = parse.unwrap_err();
+        let_assert!(
+            Err(error) =
+                Params::try_parse_from(["redder", "-X", "-s", "command"])
+        );
         check!(error.kind() == ErrorKind::UnknownArgument);
-        let value = ContextValue::String("-X".to_owned());
-        check!(error.get(ContextKind::InvalidArg) == Some(&value));
+        check!(error.get(InvalidArg) == Some(&String("-X".into())));
     }
 
     #[test]
     fn args_other_long_option_after_command() {
-        let params = Params::try_parse_from([
-            "redder",
-            "--always-color",
-            "command",
-            "--foo",
-        ])
-        .unwrap();
+        let_assert!(
+            Ok(params) = Params::try_parse_from([
+                "redder",
+                "--always-color",
+                "command",
+                "--foo",
+            ])
+        );
         check!(params.command == "command");
         check!(params.args == ["--foo"]);
         check!(params.always_color == true);
@@ -298,13 +300,14 @@ mod tests {
 
     #[test]
     fn args_other_short_option_after_command() {
-        let params = Params::try_parse_from([
-            "redder",
-            "--always-color",
-            "command",
-            "-f",
-        ])
-        .unwrap();
+        let_assert!(
+            Ok(params) = Params::try_parse_from([
+                "redder",
+                "--always-color",
+                "command",
+                "-f",
+            ])
+        );
         check!(params.command == "command");
         check!(params.args == ["-f"]);
         check!(params.always_color == true);
@@ -313,14 +316,15 @@ mod tests {
 
     #[test]
     fn args_other_mixed_option_after_command() {
-        let params = Params::try_parse_from([
-            "redder",
-            "--always-color",
-            "command",
-            "-f",
-            "--foo",
-        ])
-        .unwrap();
+        let_assert!(
+            Ok(params) = Params::try_parse_from([
+                "redder",
+                "--always-color",
+                "command",
+                "-f",
+                "--foo",
+            ])
+        );
         check!(params.command == "command");
         check!(params.args == ["-f", "--foo"]);
         check!(params.always_color == true);
@@ -330,13 +334,14 @@ mod tests {
     #[test]
     #[ignore] // FIXME clap doesn’t stop parsing after first non-flag.
     fn args_our_long_option_after_command() {
-        let params = Params::try_parse_from([
-            "redder",
-            "--always-color",
-            "command",
-            "--separate",
-        ])
-        .unwrap();
+        let_assert!(
+            Ok(params) = Params::try_parse_from([
+                "redder",
+                "--always-color",
+                "command",
+                "--separate",
+            ])
+        );
         check!(params.command == "command");
         check!(params.args == ["--separate"]);
         check!(params.always_color == true);
@@ -346,13 +351,14 @@ mod tests {
     #[test]
     #[ignore] // FIXME clap doesn’t stop parsing after first non-flag.
     fn args_our_same_long_option_after_command() {
-        let params = Params::try_parse_from([
-            "redder",
-            "--separate",
-            "command",
-            "--separate",
-        ])
-        .unwrap();
+        let_assert!(
+            Ok(params) = Params::try_parse_from([
+                "redder",
+                "--separate",
+                "command",
+                "--separate",
+            ])
+        );
         check!(params.command == "command");
         check!(params.args == ["-s"]);
         check!(params.always_color == false);
@@ -362,8 +368,10 @@ mod tests {
     #[test]
     #[ignore] // FIXME clap doesn’t stop parsing after first non-flag.
     fn args_our_short_option_after_command() {
-        let params =
-            Params::try_parse_from(["redder", "-c", "command", "-s"]).unwrap();
+        let_assert!(
+            Ok(params) =
+                Params::try_parse_from(["redder", "-c", "command", "-s"])
+        );
         check!(params.command == "command");
         check!(params.args == ["-s"]);
         check!(params.always_color == true);
@@ -373,8 +381,10 @@ mod tests {
     #[test]
     #[ignore] // FIXME clap doesn’t stop parsing after first non-flag.
     fn args_our_same_short_option_after_command() {
-        let params =
-            Params::try_parse_from(["redder", "-s", "command", "-s"]).unwrap();
+        let_assert!(
+            Ok(params) =
+                Params::try_parse_from(["redder", "-s", "command", "-s"])
+        );
         check!(params.command == "command");
         check!(params.args == ["-s"]);
         check!(params.always_color == false);
@@ -383,10 +393,11 @@ mod tests {
 
     #[test]
     fn args_command_with_args() {
-        let params = Params::try_parse_from([
-            "redder", "-s", "command", "-abc", "foo", "--", "-s", "--bar",
-        ])
-        .unwrap();
+        let_assert!(
+            Ok(params) = Params::try_parse_from([
+                "redder", "-s", "command", "-abc", "foo", "--", "-s", "--bar",
+            ])
+        );
         check!(params.command == "command");
         check!(params.args == ["-abc", "foo", "--", "-s", "--bar"]);
         check!(params.always_color == false);
@@ -395,98 +406,106 @@ mod tests {
 
     #[test]
     fn args_buffer_size_negative() {
-        let parse = Params::try_parse_from([
-            "redder",
-            "--buffer-size",
-            "-2",
-            "command",
-        ]);
-        let error = parse.expect_err("expected parse to fail");
+        let_assert!(
+            Err(error) = Params::try_parse_from([
+                "redder",
+                "--buffer-size",
+                "-2",
+                "command",
+            ])
+        );
         check!(error.kind() == ErrorKind::ValueValidation);
     }
 
     #[test]
     fn args_idle_timeout_2() {
-        let params = Params::try_parse_from([
-            "redder",
-            "--idle-timeout",
-            "2",
-            "command",
-        ])
-        .unwrap();
+        let_assert!(
+            Ok(params) = Params::try_parse_from([
+                "redder",
+                "--idle-timeout",
+                "2",
+                "command",
+            ])
+        );
         check!(params.idle_timeout == Some(Duration::from_secs(2)));
     }
 
     #[test]
     fn args_idle_timeout_2s() {
-        let params = Params::try_parse_from([
-            "redder",
-            "--idle-timeout",
-            "2s",
-            "command",
-        ])
-        .unwrap();
+        let_assert!(
+            Ok(params) = Params::try_parse_from([
+                "redder",
+                "--idle-timeout",
+                "2s",
+                "command",
+            ])
+        );
         check!(params.idle_timeout == Some(Duration::from_secs(2)));
     }
 
     #[test]
     fn args_idle_timeout_2s_1ms() {
-        let params = Params::try_parse_from([
-            "redder",
-            "--idle-timeout",
-            "2s 1ms",
-            "command",
-        ])
-        .unwrap();
+        let_assert!(
+            Ok(params) = Params::try_parse_from([
+                "redder",
+                "--idle-timeout",
+                "2s 1ms",
+                "command",
+            ])
+        );
         check!(params.idle_timeout == Some(Duration::from_millis(2001)));
     }
 
     #[test]
     fn args_idle_timeout_2h() {
-        let params = Params::try_parse_from([
-            "redder",
-            "--idle-timeout",
-            "2h",
-            "command",
-        ])
-        .unwrap();
+        let_assert!(
+            Ok(params) = Params::try_parse_from([
+                "redder",
+                "--idle-timeout",
+                "2h",
+                "command",
+            ])
+        );
         check!(params.idle_timeout == Some(Duration::from_secs(2 * 60 * 60)));
     }
 
     #[test]
     fn args_idle_timeout_negative() {
-        let parse = Params::try_parse_from([
-            "redder",
-            "--idle-timeout",
-            "-2s",
-            "command",
-        ]);
-        let error = parse.expect_err("expected parse to fail");
+        let_assert!(
+            Err(error) = Params::try_parse_from([
+                "redder",
+                "--idle-timeout",
+                "-2s",
+                "command",
+            ])
+        );
         check!(error.kind() == ErrorKind::ValueValidation);
         check!(error.to_string().contains("negative"));
     }
 
     #[test]
     fn args_idle_timeout_zero() {
-        let params = Params::try_parse_from([
-            "redder",
-            "--idle-timeout",
-            "0",
-            "command",
-        ])
-        .unwrap();
+        let_assert!(
+            Ok(params) = Params::try_parse_from([
+                "redder",
+                "--idle-timeout",
+                "0",
+                "command",
+            ])
+        );
         check!(params.idle_timeout == Some(Duration::ZERO));
     }
 
     #[test]
     fn args_idle_timeout_maximum() {
-        let params = Params::try_parse_from([
-            "redder",
-            "--idle-timeout",
-            &format!("{}ms", i32::MAX),
-            "command",
-        ])
-        .unwrap();
+        let_assert!(
+            Ok(params) = Params::try_parse_from([
+                "redder",
+                "--idle-timeout",
+                &format!("{}ms", i32::MAX),
+                "command",
+            ])
+        );
         check!(
             params.idle_timeout == Some(Duration::from_millis(i32::MAX as u64))
         );
@@ -494,39 +513,42 @@ mod tests {
 
     #[test]
     fn args_idle_timeout_too_large() {
-        let parse = Params::try_parse_from([
-            "redder",
-            "--idle-timeout",
-            &format!("{}", i32::MAX as u64 + 1),
-            "command",
-        ]);
-        let error = parse.expect_err("expected parse to fail");
+        let_assert!(
+            Err(error) = Params::try_parse_from([
+                "redder",
+                "--idle-timeout",
+                &format!("{}", i32::MAX as u64 + 1),
+                "command",
+            ])
+        );
         check!(error.kind() == ErrorKind::ValueValidation);
         check!(error.to_string().contains("cannot be larger"));
     }
 
     #[test]
     fn args_idle_timeout_too_large_days() {
-        let parse = Params::try_parse_from([
-            "redder",
-            "--idle-timeout",
-            "26day",
-            "command",
-        ]);
-        let error = parse.expect_err("expected parse to fail");
+        let_assert!(
+            Err(error) = Params::try_parse_from([
+                "redder",
+                "--idle-timeout",
+                "26day",
+                "command",
+            ])
+        );
         check!(error.kind() == ErrorKind::ValueValidation);
         check!(error.to_string().contains("cannot be larger"));
     }
 
     #[test]
     fn args_idle_timeout_overly_precise() {
-        let parse = Params::try_parse_from([
-            "redder",
-            "--idle-timeout",
-            "2s 2ms 2ns",
-            "command",
-        ]);
-        let error = parse.expect_err("expected parse to fail");
+        let_assert!(
+            Err(error) = Params::try_parse_from([
+                "redder",
+                "--idle-timeout",
+                "2s 2ms 2ns",
+                "command",
+            ])
+        );
         check!(error.kind() == ErrorKind::ValueValidation);
         check!(error.to_string().contains("milliseconds"));
     }


### PR DESCRIPTION
The assert2 crate does everything my assertify crate does and more. In particular, it provides `check!` to allow multiple failures in the same test, which may make failures clearer.