### PR TITLE
Remove libc from Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,7 +306,6 @@ dependencies = [
  "bstr",
  "clap",
  "duration-str",
- "libc",
  "popol",
  "termcolor",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ atty = "0.2.14"
 bstr = { version = "1.1.0", default-features = false }
 clap = { version = "4.0.17", features = ["derive"] }
 duration-str = { version = "0.5.0", default-features = false }
-libc = "0.2.126"
 popol = "2.0.0"
 termcolor = "1.1.3"
 


### PR DESCRIPTION
We used to call libc directly, but that code has since been contributed to popol.