### PR TITLE
more tests

### DIFF
--- a/tests/exit.rs
+++ b/tests/exit.rs
@@ -1,6 +1,7 @@
 //! Test handling of child processes exiting various ways.
 use assert2::check;
 use assert_cmd::prelude::*;
+use bstr::ByteSlice;
 use nix::sys::signal::{kill, Signal};
 use nix::unistd::Pid;
 use std::os::unix::process::ExitStatusExt;
@@ -18,8 +19,8 @@ fn child_success() {
     let output = command.args(["true"]).output().unwrap();
 
     check!(output.status.success());
-    check!(output.stdout.is_empty());
-    check!(output.stderr.is_empty());
+    check!(output.stdout.as_bstr() == "");
+    check!(output.stderr.as_bstr() == "");
 }
 
 #[test]
@@ -28,8 +29,8 @@ fn child_failure() {
     let output = command.args(["false"]).output().unwrap();
 
     check!(output.status.code() == Some(1));
-    check!(output.stdout.is_empty());
-    check!(output.stderr.is_empty());
+    check!(output.stdout.as_bstr() == "");
+    check!(output.stderr.as_bstr() == "");
 }
 
 #[test]
@@ -41,7 +42,7 @@ fn child_sigterm() {
     let output = child.wait_with_output().unwrap();
 
     check!(output.status.signal() == Some(15), "Expected SIGTERM (15)");
-    check!(output.stdout.is_empty());
-    check!(output.stderr.is_empty());
+    check!(output.stdout.as_bstr() == "");
+    check!(output.stderr.as_bstr() == "");
     check!(start.elapsed() < Duration::from_secs(1));
 }

--- a/tests/fixtures/midline_sleep.sh
+++ b/tests/fixtures/midline_sleep.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo -n 111
+sleep 0.1
+echo -n 222
+sleep 0.1
+echo 333

--- a/tests/fixtures/mixed_output.sh
+++ b/tests/fixtures/mixed_output.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+echo -n 111
+sleep 0.1
+echo -n aaa >&2
+sleep 0.1
+echo 333
+sleep 0.1
+echo bbb >&2

--- a/tests/fixtures/stdouterr.sh
+++ b/tests/fixtures/stdouterr.sh
@@ -1,5 +1,5 @@
-#!/bin/zsh
-# It's often useful to have something that outputs to both stdout and stderr
+#!/bin/bash
+# Used for testing by hand, not automated testing.
 
 echo 01 stdout
 echo 02 stdout

--- a/tests/general.rs
+++ b/tests/general.rs
@@ -1,0 +1,115 @@
+use assert2::check;
+use bstr::ByteSlice;
+use std::time::{Duration, Instant};
+
+mod helpers;
+
+#[test]
+fn midline_sleep_all() {
+    let output = helpers::rederr(["tests/fixtures/midline_sleep.sh"])
+        .output()
+        .unwrap();
+
+    check!(output.status.success());
+    check!(output.stdout.as_bstr() == "111222333\n");
+    check!(output.stderr.as_bstr() == "");
+}
+
+#[test]
+fn midline_sleep_idle_timeout() {
+    let output = helpers::rederr([
+        "--idle-timeout",
+        "50ms",
+        "tests/fixtures/midline_sleep.sh",
+    ])
+    .output()
+    .unwrap();
+
+    check!(!output.status.success());
+    check!(output.stdout.as_bstr() == "111");
+    check!(output.stderr[..28].as_bstr() == "Timed out waiting for input ");
+}
+
+#[test]
+fn midline_sleep_run_timeout() {
+    let start = Instant::now();
+    let output = helpers::rederr([
+        "--idle-timeout",
+        "150ms",
+        "--run-timeout",
+        "150ms",
+        "tests/fixtures/midline_sleep.sh",
+    ])
+    .output()
+    .unwrap();
+
+    check!(!output.status.success());
+    check!(output.stdout.as_bstr() == "111222");
+    check!(output.stderr[..14].as_bstr() == "Run timed out ");
+    check!(start.elapsed() < Duration::from_millis(200));
+}
+
+#[test]
+fn midline_sleep_unused_timeouts() {
+    let start = Instant::now();
+    let output = helpers::rederr([
+        "--idle-timeout",
+        "150ms",
+        "--run-timeout",
+        "500ms",
+        "tests/fixtures/midline_sleep.sh",
+    ])
+    .output()
+    .unwrap();
+
+    check!(output.status.success());
+    check!(output.stdout.as_bstr() == "111222333\n");
+    check!(output.stderr.as_bstr() == "");
+    check!(start.elapsed() > Duration::from_millis(200));
+}
+
+#[test]
+fn mixed_output_no_color_combined() {
+    let output = helpers::rederr(["tests/fixtures/mixed_output.sh"])
+        .output()
+        .unwrap();
+
+    check!(output.status.success());
+    check!(output.stdout.as_bstr() == "111aaa333\nbbb\n");
+    check!(output.stderr.as_bstr() == "");
+}
+
+#[test]
+fn mixed_output_no_color_split() {
+    let output = helpers::rederr(["-s", "tests/fixtures/mixed_output.sh"])
+        .output()
+        .unwrap();
+
+    check!(output.status.success());
+    check!(output.stdout.as_bstr() == "111333\n");
+    check!(output.stderr.as_bstr() == "aaabbb\n");
+}
+
+#[test]
+fn mixed_output_color_combined() {
+    let output = helpers::rederr(["-c", "tests/fixtures/mixed_output.sh"])
+        .output()
+        .unwrap();
+
+    check!(output.status.success());
+    check!(output.stdout.as_bstr() ==
+        "111\u{1b}[0m\u{1b}[38;5;9maaa\u{1b}[0m333\n\u{1b}[0m\u{1b}[38;5;9mbbb\n\u{1b}[0m");
+    check!(output.stderr.as_bstr() == "");
+}
+
+#[test]
+fn mixed_output_color_split() {
+    let output = helpers::rederr(["-cs", "tests/fixtures/mixed_output.sh"])
+        .output()
+        .unwrap();
+
+    check!(output.status.success());
+    check!(output.stdout.as_bstr() == "111333\n");
+    check!(output.stderr.as_bstr() ==
+        "\u{1b}[0m\u{1b}[38;5;9maaa\u{1b}[0m\u{1b}[0m\u{1b}[38;5;9mbbb\n\u{1b}[0m");
+}

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -1,0 +1,13 @@
+use assert_cmd::prelude::*;
+use std::ffi::OsStr;
+use std::process::Command;
+
+pub fn rederr<I, S>(args: I) -> Command
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let mut command = Command::cargo_bin("rederr").unwrap();
+    command.args(args);
+    command
+}


### PR DESCRIPTION
- Move stdouterr.sh to tests/fixtures/.
- tests/exit.rs: better error messages
- Add `rederr` helper function to integration tests.
- Add integration tests for basic functionality.

Part of #19.