### PR TITLE
Basic release tooling

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,93 @@
+# Mostly copied from https://github.com/taiki-e/cargo-hack/blob/72a9fc95377c453a18026329577c59fa60bfa737/.github/workflows/release.yml
+name: Release
+
+permissions:
+  # TODO: once `releases: write` is supported, use it instead.
+  contents: write
+
+on:
+  push:
+    tags:
+      - v*.*.*
+
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  RUSTFLAGS: -D warnings
+  RUSTUP_MAX_RETRIES: 10
+
+defaults:
+  run:
+    # Setting shell: bash explicitly activates pipefail
+    shell: bash
+
+jobs:
+  create-release:
+    if: github.repository_owner == 'danielparks'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - name: Install Rust
+        run: rustup update stable --no-self-update
+      - run: cargo package
+      - uses: taiki-e/create-gh-release-action@v1
+        with:
+          changelog: CHANGELOG.md
+          title: Release $version
+          branch: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  upload-assets:
+    name: ${{ matrix.target }}
+    if: github.repository_owner == 'danielparks'
+    needs:
+      - create-release
+    strategy:
+      matrix:
+        include:
+          - target: aarch64-unknown-linux-gnu
+          - target: aarch64-unknown-linux-musl
+          - target: aarch64-apple-darwin
+            os: macos-11
+          - target: x86_64-unknown-linux-gnu
+          - target: x86_64-unknown-linux-musl
+          - target: x86_64-apple-darwin
+            os: macos-11
+          - target: x86_64-unknown-freebsd
+    runs-on: ${{ matrix.os || 'ubuntu-20.04' }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+      - name: Install Rust
+        run: rustup update stable --no-self-update
+      - uses: taiki-e/setup-cross-toolchain-action@v1
+        with:
+          target: ${{ matrix.target }}
+        if: (matrix.os == '' || startsWith(matrix.os, 'ubuntu')) && !contains(matrix.target, '-musl')
+      - uses: taiki-e/install-action@cross
+        if: contains(matrix.target, '-musl')
+      - run: echo "RUSTFLAGS=${RUSTFLAGS} -C target-feature=+crt-static" >> "${GITHUB_ENV}"
+        if: endsWith(matrix.target, 'windows-msvc')
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: cargo-${{ runner.os }}-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
+      - uses: taiki-e/upload-rust-binary-action@v1
+        with:
+          bin: git-status-vars
+          target: ${{ matrix.target }}
+          tar: all
+          zip: windows
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Change log
+
+All notable changes to this project will be documented in this file.
+
+## main branch
+
+* Added change log.

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+set -eo pipefail
+shopt -s extglob
+
+version=$1
+
+awk-in-place () {
+  local tmpfile=$(mktemp)
+  local original="$1"
+  shift
+  cp "$original" "$tmpfile"
+  awk "$@" <"$tmpfile" >"$original"
+  rm "$tmpfile"
+}
+
+confirm () {
+  local prompt="$1"
+  local answer
+  read -n 1 -p "${prompt} [yN] " answer
+  case $answer in
+    [yY]*) echo ;; # Continue
+    *) echo ; echo Canceling. >&2 ; exit 1 ;;
+  esac
+}
+
+case $version in
+  +([0-9]).+([0-9]).+([0-9])) ;; # Good
+  *) echo "Usage $0 VERSION" >&2 ; exit 1 ;;
+esac
+
+echo 'Making sure version is correct.'
+
+awk-in-place Cargo.toml '
+  /^version *=/ && !done {
+    sub(/"[0-9.]+"/, "\"'$version'\"")
+    done=1
+  }
+  { print }'
+
+sed -i '' -e 's/^version *= *".*"/version = "'$version'"/' Cargo.toml
+cargo check --quiet
+
+awk-in-place CHANGELOG.md '
+  /^## / && !done {
+    $0 = "## Release '$version' ('$(date +%Y-%m-%d)')"
+    done=1
+  }
+  { print }'
+
+# Check for changes
+if git ls-files --exclude-standard --other | grep . >/dev/null ; then
+  echo 'Found untracked files:' >&2
+  git ls-files --exclude-standard --other | sed -e 's/^/  /' >&2
+  echo >&2
+  echo 'Please commit changes before proceeding.' >&2
+  exit 1
+fi
+
+git diff --color --exit-code HEAD || {
+  echo >&2
+  echo 'Please commit changes before proceeding.' >&2
+  exit 1
+}
+
+# Confirm changelog
+changelog=$(mktemp)
+{
+  echo "## Release ${version}"
+  echo
+  parse-changelog CHANGELOG.md "$version"
+} >"$changelog"
+
+cat "$changelog"
+echo
+confirm 'Release notes displayed above. Continue?'
+
+git tag --sign --file "$changelog" --cleanup=verbatim "v${version}"
+git push --tags origin main
+
+awk-in-place CHANGELOG.md '
+  /^## Release/ && !done {
+    print "## main branch\n"
+    done=1
+  }
+  { print }'
+
+git add CHANGELOG.md
+git diff --staged
+
+confirm 'Commit with message "Prepping CHANGELOG.md for development."?'
+
+git commit -m 'Prepping CHANGELOG.md for development.'


### PR DESCRIPTION
Adds:

  * `CHANGELOG.md`: just a stub a change log.
  * `release.sh` manage version, manage `CHANGELOG.md`, and update version.
  * Release workflow for GitHub actions to create a GitHub release, build binaries, and publish to crates.io.

Mostly just copied wholesale from [git-status-vars][].

[git-status-vars]: https://github.com/danielparks/git-status-vars