### PR TITLE
Forbid unsafe code

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 use bstr::ByteSlice;
 use clap::Parser;
 use popol::set_nonblocking;


### PR DESCRIPTION
It seems unlikely I’ll need `unsafe`. Make that explicit.