### PR TITLE
Use cargo-lints to centrally configure lints

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -38,10 +38,10 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: clippy
-      - uses: actions-rs/clippy-check@v1
+      - uses: taiki-e/install-action@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features --all-targets
+          tool: cargo-lints
+      - run: cargo lints clippy --all-features --all-targets
 
   deny:
     name: cargo deny

--- a/lints.toml
+++ b/lints.toml
@@ -1,0 +1,51 @@
+deny = [
+  "unsafe_code",
+]
+
+warn = [
+  "clippy::nursery",
+  "clippy::pedantic",
+
+  # Require docs
+  "missing_docs",
+  "clippy::missing_docs_in_private_items",
+
+  # Other restriction lints
+  "clippy::arithmetic_side_effects",
+  "clippy::as_underscore",
+  "clippy::assertions_on_result_states",
+  "clippy::dbg_macro",
+  "clippy::default_union_representation",
+  "clippy::empty_structs_with_brackets",
+  "clippy::filetype_is_file", # maybe?
+  "clippy::fn_to_numeric_cast_any",
+  "clippy::format_push_string", # maybe? alternative is fallible.
+  "clippy::get_unwrap",
+  "clippy::impl_trait_in_params",
+  "clippy::integer_division",
+  "clippy::lossy_float_literal",
+  "clippy::mem_forget",
+  "clippy::mixed_read_write_in_expression",
+  "clippy::multiple_inherent_impl",
+  "clippy::multiple_unsafe_ops_per_block",
+  "clippy::mutex_atomic",
+  "clippy::rc_buffer",
+  "clippy::rc_mutex",
+  "clippy::same_name_method",
+  "clippy::semicolon_inside_block",
+  "clippy::str_to_string",
+  "clippy::string_to_string",
+  "clippy::undocumented_unsafe_blocks",
+  "clippy::unnecessary_safety_doc",
+  "clippy::unnecessary_self_imports",
+  "clippy::unneeded_field_pattern",
+  "clippy::verbose_file_reads",
+]
+
+allow = [
+  # Pedantic exceptions
+  "clippy::let_underscore_untyped",
+  "clippy::manual_string_new",
+  "clippy::map_unwrap_or",
+  "clippy::module_name_repetitions",
+]


### PR DESCRIPTION
Previously lints had to be configured at the top of every entry point in rust code — `main.rs` and each test file. This allows lints to be centrally configured in `lints.toml` and ensures they are applied to all targets.

To run lints:

    cargo lints clippy --all-targets --all-features

This requires [cargo-lints] to be installed.

[cargo-lints]: https://crates.io/crates/cargo-lints