### PR TITLE
`cargo update`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,6 @@ All notable changes to this project will be documented in this file.
 ## main branch
 
 * Added change log.
+* Updated anyhow to avoid [RUSTSEC-2026-0190] (likely did not affect rederr).
+
+[RUSTSEC-2026-0190]: https://rustsec.org/advisories/RUSTSEC-2026-0190

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,9 +53,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.94"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arrayvec"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,7 +38,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -48,7 +48,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
 dependencies = [
  "anstyle",
- "windows-sys 0.59.0",
+ "windows-sys",
 ]
 
 [[package]]
@@ -65,21 +65,22 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "assert2"
-version = "0.3.15"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d31fea2b6e18dfe892863c3a0a68f9e005b0195565f3d55b8612946ebca789cc"
+checksum = "a1f7e619706e24555d32d89b4446960bec3d085d1f488c659874b0929998bc28"
 dependencies = [
  "assert2-macros",
  "diff",
- "is-terminal",
+ "terminal_size",
+ "unicode-width",
  "yansi",
 ]
 
 [[package]]
 name = "assert2-macros"
-version = "0.3.15"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c1ac052c642f6d94e4be0b33028b346b7ab809ea5432b584eb8859f12f7ad2c"
+checksum = "347ba98d9bd5467cf7e5b5ea0a90b509d9b589060b302fcc0d9ae6268ff7e02e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -204,13 +205,23 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "duration-str"
-version = "0.11.3"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f88959de2d447fd3eddcf1909d1f19fe084e27a056a6904203dc5d8b9e771c1e"
+checksum = "027cd1402a609c71a9ac333c7e3d90ee042e7a131da1a83da8c60df323f12f61"
 dependencies = [
  "rust_decimal",
  "thiserror",
  "winnow",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
 ]
 
 [[package]]
@@ -220,23 +231,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
-
-[[package]]
-name = "is-terminal"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -244,9 +238,15 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "libc"
-version = "0.2.167"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "memchr"
@@ -256,9 +256,9 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "nix"
-version = "0.29.0"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -370,6 +370,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -422,6 +435,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
+dependencies = [
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "termtree"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -454,6 +477,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -474,16 +503,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
+ "windows-sys",
 ]
 
 [[package]]
@@ -561,9 +581,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.20"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2021"
 rust-version = "1.81"
 
 [dependencies]
-anyhow = "1.0.44"
+anyhow = "1.0.103"
 bstr = { version = "1.1.0", default-features = false }
 clap = { version = "4.5.23", features = ["derive"] }
 duration-str = { version = "0.11.3", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,14 +16,14 @@ rust-version = "1.81"
 anyhow = "1.0.103"
 bstr = { version = "1.1.0", default-features = false }
 clap = { version = "4.5.23", features = ["derive"] }
-duration-str = { version = "0.11.3", default-features = false }
+duration-str = { version = "0.21.0", default-features = false }
 popol = "3.0.0"
 termcolor = "1.1.3"
 
 [dev-dependencies]
-assert2 = "0.3.15"
+assert2 = "0.4.0"
 assert_cmd = "2.0.7"
-nix = { version = "0.29.0", default-features = false, features = ["signal", "process"] }
+nix = { version = "0.31.3", default-features = false, features = ["signal", "process"] }
 
 [lints]
 workspace = true

--- a/src/params.rs
+++ b/src/params.rs
@@ -122,7 +122,7 @@ fn parse_duration(input: &str) -> anyhow::Result<Duration> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use assert2::{check, let_assert};
+    use assert2::{assert, check};
     use clap::error::{
         ContextKind::InvalidArg, ContextValue::String, ErrorKind,
     };
@@ -130,8 +130,8 @@ mod tests {
 
     #[test]
     fn args_invalid_long_option() {
-        let_assert!(
-            Err(error) =
+        assert!(
+            let Err(error) =
                 Params::try_parse_from(["redder", "--foo", "-s", "command"])
         );
         check!(error.kind() == ErrorKind::UnknownArgument);
@@ -140,8 +140,8 @@ mod tests {
 
     #[test]
     fn args_invalid_short_option() {
-        let_assert!(
-            Err(error) =
+        assert!(
+            let Err(error) =
                 Params::try_parse_from(["redder", "-X", "-s", "command"])
         );
         check!(error.kind() == ErrorKind::UnknownArgument);
@@ -150,8 +150,8 @@ mod tests {
 
     #[test]
     fn args_other_long_option_after_command() {
-        let_assert!(
-            Ok(params) = Params::try_parse_from([
+        assert!(
+            let Ok(params) = Params::try_parse_from([
                 "redder",
                 "--always-color",
                 "command",
@@ -166,8 +166,8 @@ mod tests {
 
     #[test]
     fn args_other_short_option_after_command() {
-        let_assert!(
-            Ok(params) = Params::try_parse_from([
+        assert!(
+            let Ok(params) = Params::try_parse_from([
                 "redder",
                 "--always-color",
                 "command",
@@ -182,8 +182,8 @@ mod tests {
 
     #[test]
     fn args_other_mixed_option_after_command() {
-        let_assert!(
-            Ok(params) = Params::try_parse_from([
+        assert!(
+            let Ok(params) = Params::try_parse_from([
                 "redder",
                 "--always-color",
                 "command",
@@ -200,8 +200,8 @@ mod tests {
     #[test]
     #[ignore = "clap doesn’t stop parsing after first non-flag"]
     fn args_our_long_option_after_command() {
-        let_assert!(
-            Ok(params) = Params::try_parse_from([
+        assert!(
+            let Ok(params) = Params::try_parse_from([
                 "redder",
                 "--always-color",
                 "command",
@@ -217,8 +217,8 @@ mod tests {
     #[test]
     #[ignore = "clap doesn’t stop parsing after first non-flag"]
     fn args_our_same_long_option_after_command() {
-        let_assert!(
-            Ok(params) = Params::try_parse_from([
+        assert!(
+            let Ok(params) = Params::try_parse_from([
                 "redder",
                 "--separate",
                 "command",
@@ -234,8 +234,8 @@ mod tests {
     #[test]
     #[ignore = "clap doesn’t stop parsing after first non-flag"]
     fn args_our_short_option_after_command() {
-        let_assert!(
-            Ok(params) =
+        assert!(
+            let Ok(params) =
                 Params::try_parse_from(["redder", "-c", "command", "-s"])
         );
         check!(params.command == "command");
@@ -247,8 +247,8 @@ mod tests {
     #[test]
     #[ignore = "clap doesn’t stop parsing after first non-flag"]
     fn args_our_same_short_option_after_command() {
-        let_assert!(
-            Ok(params) =
+        assert!(
+            let Ok(params) =
                 Params::try_parse_from(["redder", "-s", "command", "-s"])
         );
         check!(params.command == "command");
@@ -259,8 +259,8 @@ mod tests {
 
     #[test]
     fn args_command_with_args() {
-        let_assert!(
-            Ok(params) = Params::try_parse_from([
+        assert!(
+            let Ok(params) = Params::try_parse_from([
                 "redder", "-s", "command", "-abc", "foo", "--", "-s", "--bar",
             ])
         );
@@ -272,8 +272,8 @@ mod tests {
 
     #[test]
     fn args_buffer_size_negative() {
-        let_assert!(
-            Err(error) = Params::try_parse_from([
+        assert!(
+            let Err(error) = Params::try_parse_from([
                 "redder",
                 "--buffer-size",
                 "-2",
@@ -285,8 +285,8 @@ mod tests {
 
     #[test]
     fn args_idle_timeout_2() {
-        let_assert!(
-            Ok(params) = Params::try_parse_from([
+        assert!(
+            let Ok(params) = Params::try_parse_from([
                 "redder",
                 "--idle-timeout",
                 "2",
@@ -298,8 +298,8 @@ mod tests {
 
     #[test]
     fn args_idle_timeout_2s() {
-        let_assert!(
-            Ok(params) = Params::try_parse_from([
+        assert!(
+            let Ok(params) = Params::try_parse_from([
                 "redder",
                 "--idle-timeout",
                 "2s",
@@ -311,8 +311,8 @@ mod tests {
 
     #[test]
     fn args_idle_timeout_2s_1ms() {
-        let_assert!(
-            Ok(params) = Params::try_parse_from([
+        assert!(
+            let Ok(params) = Params::try_parse_from([
                 "redder",
                 "--idle-timeout",
                 "2s 1ms",
@@ -324,8 +324,8 @@ mod tests {
 
     #[test]
     fn args_idle_timeout_2h() {
-        let_assert!(
-            Ok(params) = Params::try_parse_from([
+        assert!(
+            let Ok(params) = Params::try_parse_from([
                 "redder",
                 "--idle-timeout",
                 "2h",
@@ -337,8 +337,8 @@ mod tests {
 
     #[test]
     fn args_idle_timeout_negative() {
-        let_assert!(
-            Err(error) = Params::try_parse_from([
+        assert!(
+            let Err(error) = Params::try_parse_from([
                 "redder",
                 "--idle-timeout",
                 "-2s",
@@ -351,8 +351,8 @@ mod tests {
 
     #[test]
     fn args_idle_timeout_zero() {
-        let_assert!(
-            Ok(params) = Params::try_parse_from([
+        assert!(
+            let Ok(params) = Params::try_parse_from([
                 "redder",
                 "--idle-timeout",
                 "0",
@@ -364,8 +364,8 @@ mod tests {
 
     #[test]
     fn args_idle_timeout_maximum() {
-        let_assert!(
-            Ok(params) = Params::try_parse_from([
+        assert!(
+            let Ok(params) = Params::try_parse_from([
                 "redder",
                 "--idle-timeout",
                 &format!("{}ms", i32::MAX),
@@ -379,8 +379,8 @@ mod tests {
 
     #[test]
     fn args_idle_timeout_overly_precise() {
-        let_assert!(
-            Err(error) = Params::try_parse_from([
+        assert!(
+            let Err(error) = Params::try_parse_from([
                 "redder",
                 "--idle-timeout",
                 "2s 2ms 2ns",

--- a/src/timeout.rs
+++ b/src/timeout.rs
@@ -34,12 +34,13 @@ pub enum Timeout {
     /// timeout. For example:
     ///
     /// ```rust
-    /// use assert2::let_assert;
+    /// use assert2::assert;
     /// use cron_wrapper::timeout::Timeout;
     /// use std::time::Duration;
     ///
-    /// let_assert!(
-    ///     Timeout::Future { .. } = Timeout::from(Duration::from_millis(100))
+    /// assert!(
+    ///     let Timeout::Future { .. }
+    ///         = Timeout::from(Duration::from_millis(100))
     /// );
     /// ```
     Future {
@@ -232,7 +233,7 @@ mod tests {
     )]
 
     use super::*;
-    use assert2::{check, let_assert};
+    use assert2::{assert, check};
     use std::time::Duration;
 
     const fn future_timeout(microseconds: u64) -> Timeout {
@@ -382,8 +383,8 @@ mod tests {
 
     #[test]
     fn check_expired_timeout_pending_overtime() {
-        let_assert!(
-            Some(Timeout::Expired { .. }) =
+        assert!(
+            let Some(Timeout::Expired { .. }) =
                 pending_timeout(5_000, 6_000).check_expired()
         );
     }


### PR DESCRIPTION
- **Security: update anyhow to avoid potential unsoundness**
  [RUSTSEC-2026-0190](https://rustsec.org/advisories/RUSTSEC-2026-0190):
  
  > Affected versions of this crate violate borrow rules, resulting in
  > undefined behavior, when the user adds context to an error via
  > `Error::context` and then later calls `Error::downcast_mut` on the
  > returned `Error`.
  
  Likely does not affect this crate.
  

- **`cargo +nightly -Z unstable-options update -b`**
  The new version of `assert2` required converting all `let_assert!(...)`
  calls to `assert!(let ...)`.
  